### PR TITLE
Bug: AboutCommandTests need to dispose of `IDisposable` resources emitted by a helper method.

### DIFF
--- a/tests/BadMango.Emulator.Debug.UI.Tests/AboutCommandTests.cs
+++ b/tests/BadMango.Emulator.Debug.UI.Tests/AboutCommandTests.cs
@@ -41,14 +41,21 @@ public class AboutCommandTests
         var command = new AboutCommand();
         var context = CreateTestContext(out var outputWriter);
 
-        var result = command.Execute(context, []);
-
-        Assert.Multiple(() =>
+        try
         {
-            Assert.That(result.Success, Is.True);
-            Assert.That(outputWriter.ToString(), Does.Contain("BackPocket BASIC"));
-            Assert.That(outputWriter.ToString(), Does.Contain("Copyright"));
-        });
+            var result = command.Execute(context, []);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.Success, Is.True);
+                Assert.That(outputWriter.ToString(), Does.Contain("BackPocket BASIC"));
+                Assert.That(outputWriter.ToString(), Does.Contain("Copyright"));
+            });
+        }
+        finally
+        {
+            outputWriter.Dispose();
+        }
     }
 
     /// <summary>
@@ -63,16 +70,23 @@ public class AboutCommandTests
         windowManager.Setup(w => w.ShowWindowAsync(It.IsAny<string>())).ReturnsAsync(true);
 
         var command = new AboutCommand(windowManager.Object);
-        var context = CreateTestContext(out _);
+        var context = CreateTestContext(out var outputWriter);
 
-        var result = command.Execute(context, []);
-
-        Assert.Multiple(() =>
+        try
         {
-            Assert.That(result.Success, Is.True);
-            Assert.That(result.Message, Does.Contain("Opening"));
-            windowManager.Verify(w => w.ShowWindowAsync("About"), Times.Once);
-        });
+            var result = command.Execute(context, []);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.Success, Is.True);
+                Assert.That(result.Message, Does.Contain("Opening"));
+                windowManager.Verify(w => w.ShowWindowAsync("About"), Times.Once);
+            });
+        }
+        finally
+        {
+            outputWriter.Dispose();
+        }
     }
 
     /// <summary>
@@ -86,16 +100,23 @@ public class AboutCommandTests
         windowManager.Setup(w => w.ShowWindowAsync(It.IsAny<string>())).ReturnsAsync(true);
 
         var command = new AboutCommand(windowManager.Object);
-        var context = CreateTestContext(out _);
+        var context = CreateTestContext(out var outputWriter);
 
-        var result = command.Execute(context, []);
-
-        Assert.Multiple(() =>
+        try
         {
-            Assert.That(result.Success, Is.True);
-            Assert.That(result.Message, Does.Contain("Opening"));
-            windowManager.Verify(w => w.ShowWindowAsync("About"), Times.Once);
-        });
+            var result = command.Execute(context, []);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.Success, Is.True);
+                Assert.That(result.Message, Does.Contain("Opening"));
+                windowManager.Verify(w => w.ShowWindowAsync("About"), Times.Once);
+            });
+        }
+        finally
+        {
+            outputWriter.Dispose();
+        }
     }
 
     /// <summary>
@@ -112,15 +133,22 @@ public class AboutCommandTests
         windowManager.Setup(w => w.ShowWindowAsync(It.IsAny<string>())).Returns(tcs.Task);
 
         var command = new AboutCommand(windowManager.Object);
-        var context = CreateTestContext(out _);
+        var context = CreateTestContext(out var outputWriter);
 
-        // Execute should return immediately without blocking
-        var result = command.Execute(context, []);
+        try
+        {
+            // Execute should return immediately without blocking
+            var result = command.Execute(context, []);
 
-        Assert.That(result.Success, Is.True);
+            Assert.That(result.Success, Is.True);
 
-        // Complete the task to clean up
-        tcs.SetResult(true);
+            // Complete the task to clean up
+            tcs.SetResult(true);
+        }
+        finally
+        {
+            outputWriter.Dispose();
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
## Description
Fix the tests to properly dispose of an `IDisposable` resource produced by a helper method.

## Type of Change
Please check the relevant option(s):

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test coverage improvement

## Changes Made
List the key changes made in this PR:

- Wrap act/assert steps in a try..finally block
- Dispose of the resource in the finally block 

## Testing
Describe the tests you ran to verify your changes:

- [X] All existing tests pass
- [ ] Added new tests for new functionality
- [ ] Manually tested the changes
- [ ] Tested on multiple platforms (if applicable)

## Checklist
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published

## Additional Notes
Addresses some missed PR comments.